### PR TITLE
refactor: export IntermediateFileFormat

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,14 +1,13 @@
 import * as rollup from 'rollup';
 import * as acorn from 'acorn';
 import {CreateFilter} from 'rollup-pluginutils';
-type valueof<T> = T[keyof T]
 
-export enum IntermediateFileFormat {
-    import = 'import',
-    named = 'named',
-    default = 'default',
-    mixed = 'mixed',
-}
+export const IntermediateFileFormat: {
+    import: 'import',
+    named: 'named',
+    default: 'default',
+    mixed: 'mixed',
+};
 
 export interface IGlobPluginOptions {
     /**
@@ -27,7 +26,7 @@ export interface IGlobPluginOptions {
      *   [acorn](https://www.npmjs.com/package/acorn) to check default exports.
      *   Intermediate files export both named exports and default exports.
      */
-    format?: valueof<IntermediateFileFormat>,
+    format?: keyof typeof IntermediateFileFormat,
     /**
      * A function generates the name of exports.
      * It is used if `options.format` is `'mixed'` or `'default'`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ const IntermediateFileFormat = {
 };
 
 const codeGenerator = {
-    default(files, importer, options) {
+    [IntermediateFileFormat.default](files, importer, options) {
         const lines = [];
         for (let i = 0; i < files.length; i++) {
             const file = files[i];
@@ -31,13 +31,13 @@ const codeGenerator = {
         }
         return lines.join('\n');
     },
-    named(files) {
+    [IntermediateFileFormat.named](files) {
         return files.map((file) => `export * from ${JSON.stringify(file)};`).join('\n');
     },
-    import(files) {
+    [IntermediateFileFormat.import](files) {
         return files.map((file) => `import ${JSON.stringify(file)};`).join('\n');
     },
-    async mixed(files, importer, options) {
+    async [IntermediateFileFormat.mixed](files, importer, options) {
         const acornOptions = Object.assign({sourceType: 'module'}, options.acorn);
         const lines = await Promise.all(files.map(async (file, index) => {
             const id = path.join(path.dirname(importer), file);
@@ -89,9 +89,9 @@ const codeGenerator = {
 };
 
 const plugin = (options = {}) => {
-    options = Object.assign({format: 'mixed'}, options);
-    if (options.rename && options.format !== 'default') {
-        options.format = 'mixed';
+    options = Object.assign({format: IntermediateFileFormat.mixed}, options);
+    if (options.rename && options.format !== IntermediateFileFormat.default) {
+        options.format = IntermediateFileFormat.mixed;
     }
     options.rename = options.rename || defaultRenamer;
     const generateCode = codeGenerator[options.format];

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,9 +5,7 @@ const {createFilter} = require('rollup-pluginutils');
 const readFile = promisify(fs.readFile);
 const glob = promisify(require('glob'));
 const camelCase = (input) => input.replace(/[-+*/:;.'"`?!&~|<>^%#=@[\]{}()\s\\]+([a-z]|$)/g, (_match, c) => c.toUpperCase());
-const defaultRenamer = (name, id) => {
-    return name || camelCase(path.basename(id, path.extname(id)));
-};
+const defaultRenamer = (name, id) => name || camelCase(path.basename(id, path.extname(id)));
 const IntermediateFileFormat = {
     import: 'import',
     named: 'named',
@@ -96,7 +94,7 @@ const plugin = (options = {}) => {
     options.rename = options.rename || defaultRenamer;
     const generateCode = codeGenerator[options.format];
     if (!generateCode) {
-        throw new Error(`Invalid format: ${options.format}`);
+        throw new Error(`InvalidFormat: ${options.format}`);
     }
     const filter = createFilter(options.include, options.exclude);
     const generatedCodes = new Map();

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,12 @@ const camelCase = (input) => input.replace(/[-+*/:;.'"`?!&~|<>^%#=@[\]{}()\s\\]+
 const defaultRenamer = (name, id) => {
     return name || camelCase(path.basename(id, path.extname(id)));
 };
+const IntermediateFileFormat = {
+    import: 'import',
+    named: 'named',
+    default: 'default',
+    mixed: 'mixed',
+};
 
 const codeGenerator = {
     default(files, importer, options) {
@@ -19,7 +25,7 @@ const codeGenerator = {
             if (exported) {
                 lines.push(
                     `import _${i} from ${JSON.stringify(file)};`,
-                    `export {_${i} as ${exported}};`
+                    `export {_${i} as ${exported}};`,
                 );
             }
         }
@@ -122,5 +128,6 @@ module.exports = Object.assign(
         plugin,
         defaultRenamer,
         camelCase,
+        IntermediateFileFormat,
     },
 );


### PR DESCRIPTION
https://github.com/kei-ito/rollup-plugin-glob-import/pull/68#discussion_r345637347

This PR removes `export enum IntermediateFileFormat` and adds `export const IntermediateFileFormat`.